### PR TITLE
Update only those fields that are defined in the scrapy `Item`

### DIFF
--- a/scrapymongodb.py
+++ b/scrapymongodb.py
@@ -43,7 +43,7 @@ class MongoDBPipeline(object):
         else:
             result = self.collection.update(
                             {self.uniq_key: item[self.uniq_key]},
-                            dict(item),
+                            { '$set': dict(item) },
                             upsert=True, safe=self.safe)
 
         # If item has _id field and is None


### PR DESCRIPTION
If one add an additional field to the items in the database, they will be erased when you perform new crawling process.
